### PR TITLE
使用技術に同じ技術を選択できないよう修正

### DIFF
--- a/src/components/game/Hand.tsx
+++ b/src/components/game/Hand.tsx
@@ -1,7 +1,7 @@
-import { useAtom } from 'jotai';
-import { handAtom, selectedCardsAtom, techLevelsAtom } from '@/store/game';
-import { TechCard } from '@/components/ui/TechCard';
-import { GAME_CONFIG } from '@/const/game';
+import { useAtom } from "jotai";
+import { handAtom, selectedCardsAtom, techLevelsAtom } from "@/store/game";
+import { TechCard } from "@/components/ui/TechCard";
+import { GAME_CONFIG } from "@/const/game";
 
 export function Hand() {
   const [hand, setHand] = useAtom(handAtom);
@@ -14,6 +14,10 @@ export function Hand() {
     }
 
     const card = hand[cardIndex];
+    if (selectedCards.some((c) => c.id === card.id)) {
+      return;
+    }
+
     setSelectedCards([...selectedCards, card]);
     setHand(hand.filter((_, index) => index !== cardIndex));
   };
@@ -29,7 +33,11 @@ export function Hand() {
             techLevel={techLevels[card.id]}
             badge="手札"
             onClick={() => handleCardClick(index)}
-            className={selectedCards.length >= GAME_CONFIG.MAX_SELECTED_CARDS ? 'opacity-50 cursor-not-allowed' : ''}
+            className={
+              selectedCards.length >= GAME_CONFIG.MAX_SELECTED_CARDS
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
           />
         ))}
       </div>


### PR DESCRIPTION
## 実装内容
- SelectedCards(使用技術)に同じ技術を重複して選べないように修正

## 動作確認
- 実際にローカルで同じ技術を手札から選択しても使用技術に加わらないことを確認

## その他
- Prettier(以下略)